### PR TITLE
remove host as a concept

### DIFF
--- a/app/elements/core/button.js
+++ b/app/elements/core/button.js
@@ -38,13 +38,12 @@ const sharedStyles = Frontend.Element.html`<style>
 </style>`;
 
 Frontend.Element.Register("core-button", {
-  template: {
-    buildAttributes: {
-      disabled: Boolean
-    },
-    handleBuild({ disabled }) {
-      if (disabled)
-        return Frontend.Element.html`${sharedStyles}
+  buildAttributes: {
+    disabled: Boolean
+  },
+  handleBuild({ disabled }) {
+    if (disabled)
+      return Frontend.Element.html`${sharedStyles}
           <style>
             button {
               cursor: not-allowed;
@@ -55,7 +54,7 @@ Frontend.Element.Register("core-button", {
             <slot></slot>
           </button>`;
 
-      return Frontend.Element.html`${sharedStyles}
+    return Frontend.Element.html`${sharedStyles}
         <style>
           button:hover,
           button:active,
@@ -71,6 +70,5 @@ Frontend.Element.Register("core-button", {
         <button>
           <slot></slot>
         </button>`;
-    }
   }
 });

--- a/app/elements/core/button.js
+++ b/app/elements/core/button.js
@@ -1,7 +1,6 @@
 import Frontend from "/framework/frontend/module.js";
 
 const sharedStyles = Frontend.Element.html`<style>
-  :host,
   button {
     width: 100%;
     height: 100%;
@@ -40,7 +39,7 @@ const sharedStyles = Frontend.Element.html`<style>
 
 Frontend.Element.Register("core-button", {
   template: {
-    attributes: {
+    buildAttributes: {
       disabled: Boolean
     },
     handleBuild({ disabled }) {

--- a/app/elements/core/image.js
+++ b/app/elements/core/image.js
@@ -4,6 +4,11 @@ import "/app/elements/core/loading/skeleton.js";
 
 Frontend.Element.Register("core-image", {
   host: {
+    defaultStyles: Frontend.Element.html`<style>
+        :host {
+          display: inline-block;
+        }
+      </style>`,
     handleMount({ src, alt, ...cdnConfig }) {
       const url = new URL(src);
 
@@ -18,7 +23,7 @@ Frontend.Element.Register("core-image", {
     }
   },
   template: {
-    attributes: {
+    buildAttributes: {
       src: String,
       alt: String,
       width: String,
@@ -28,14 +33,9 @@ Frontend.Element.Register("core-image", {
     handleBuild({ width, height, loaded }) {
       if (loaded) {
         return Frontend.Element.html`<style>
-            :host {
+            img {
               width: ${width};
               height: ${height};
-              display: inline-block;
-            }
-            img {
-              width: 100%;
-              height: 100%;
               object-fit: contain;
               overflow: hidden;
               pointer-events: none;
@@ -44,13 +44,7 @@ Frontend.Element.Register("core-image", {
           ${this.__image__}`;
       }
 
-      return Frontend.Element.html`<style>
-          :host {
-            width: ${width};
-            height: ${height};
-            display: inline-block;
-          }
-        </style>
+      return Frontend.Element.html`
         <core-loading-skeleton></core-loading-skeleton>`;
     }
   }

--- a/app/elements/core/image.js
+++ b/app/elements/core/image.js
@@ -3,38 +3,30 @@ import Frontend from "/framework/frontend/module.js";
 import "/app/elements/core/loading/skeleton.js";
 
 Frontend.Element.Register("core-image", {
-  host: {
-    defaultStyles: Frontend.Element.html`<style>
-        :host {
-          display: inline-block;
-        }
-      </style>`,
-    handleMount({ src, alt, ...srcParams }) {
-      const url = new URL(src);
-
-      for (const [key, value] of Object.entries(srcParams)) {
-        url.searchParams.set(key, value);
-      }
-
-      this.__image__ = new Image(srcParams.width, srcParams.height);
-      this.__image__.onload = () =>
-        (this.template.buildAttributes.loaded = true);
-      this.__image__.src = url.toString();
-      this.__image__.alt = alt;
-    }
+  buildAttributes: {
+    src: String,
+    alt: String,
+    width: String,
+    height: String,
+    loaded: Boolean
   },
-  template: {
-    buildAttributes: {
-      src: String,
-      alt: String,
-      width: String,
-      height: String,
-      loaded: Boolean
-    },
-    handleBuild({ width, height, loaded }) {
-      if (loaded) {
-        return Frontend.Element.html`<style>
+  handleMount({ src, alt, ...srcParams }) {
+    const url = new URL(src);
+
+    for (const [key, value] of Object.entries(srcParams)) {
+      url.searchParams.set(key, value);
+    }
+
+    this.__image__ = new Image(srcParams.width, srcParams.height);
+    this.__image__.onload = () => (this.template.buildAttributes.loaded = true);
+    this.__image__.src = url.toString();
+    this.__image__.alt = alt;
+  },
+  handleBuild({ width, height, loaded }) {
+    if (loaded) {
+      return Frontend.Element.html`<style>
             img {
+              display: inline-block;
               width: ${width};
               height: ${height};
               object-fit: contain;
@@ -43,9 +35,9 @@ Frontend.Element.Register("core-image", {
             }
           </style>
           ${this.__image__}`;
-      }
+    }
 
-      return Frontend.Element.html`
+    return Frontend.Element.html`
         <style>
           core-loading-skeleton {
             display: inline-block;
@@ -54,6 +46,5 @@ Frontend.Element.Register("core-image", {
           }
         </style>
         <core-loading-skeleton></core-loading-skeleton>`;
-    }
   }
 });

--- a/app/elements/core/image.js
+++ b/app/elements/core/image.js
@@ -9,15 +9,16 @@ Frontend.Element.Register("core-image", {
           display: inline-block;
         }
       </style>`,
-    handleMount({ src, alt, ...cdnConfig }) {
+    handleMount({ src, alt, ...srcParams }) {
       const url = new URL(src);
 
-      for (const [key, value] of Object.entries(cdnConfig)) {
+      for (const [key, value] of Object.entries(srcParams)) {
         url.searchParams.set(key, value);
       }
 
-      this.__image__ = new Image(cdnConfig.width, cdnConfig.height);
-      this.__image__.onload = () => (this.template.attributes.loaded = true);
+      this.__image__ = new Image(srcParams.width, srcParams.height);
+      this.__image__.onload = () =>
+        (this.template.buildAttributes.loaded = true);
       this.__image__.src = url.toString();
       this.__image__.alt = alt;
     }
@@ -45,6 +46,13 @@ Frontend.Element.Register("core-image", {
       }
 
       return Frontend.Element.html`
+        <style>
+          core-loading-skeleton {
+            display: inline-block;
+            width: ${width};
+            height: ${height};
+          }
+        </style>
         <core-loading-skeleton></core-loading-skeleton>`;
     }
   }

--- a/app/elements/core/input.js
+++ b/app/elements/core/input.js
@@ -55,50 +55,47 @@ const sharedStyles = Frontend.Element.html`<style>
 const makeLabelID = (label) => label.toLowerCase().replace(/\s/g, "-");
 
 Frontend.Element.Register("core-input", {
-  host: {
-    handleMount({ label = "" }) {
-      this.setAttribute("tabIndex", 0);
-      this.setAttribute("role", "input");
-
-      const __inputID__ = makeLabelID(label);
-
-      this.addEventListener("focus", () =>
-        this.template.getElementById(__inputID__).focus()
-      );
-
-      this.addEventListener("input", ({ target }) => {
-        const value =
-          target.localName === "input" ? target.value : target.textContent;
-
-        this.value = value;
-
-        this.template
-          .querySelector("label")
-          .classList.toggle("hidden", Boolean(value));
-      });
-    }
+  buildAttributes: {
+    label: String,
+    type: String
   },
-  template: {
-    buildAttributes: {
-      label: String,
-      type: String
-    },
-    handleBuild({ label = "", type = "content" }) {
-      const __inputID__ = makeLabelID(label);
+  handleMount({ label = "" }) {
+    this.setAttribute("tabIndex", 0);
+    this.setAttribute("role", "input");
 
-      let inputElement;
+    const __inputID__ = makeLabelID(label);
 
-      switch (type) {
-        case "text":
-        case "password":
-        case "email":
-        case "search":
-          inputElement = Frontend.Element
-            .html`<input id="${__inputID__}" type="${type}">`;
-          break;
-        case "content":
-        default:
-          inputElement = Frontend.Element.html`
+    this.addEventListener("focus", () =>
+      this.template.getElementById(__inputID__).focus()
+    );
+
+    this.addEventListener("input", ({ target }) => {
+      const value =
+        target.localName === "input" ? target.value : target.textContent;
+
+      this.value = value;
+
+      this.template
+        .querySelector("label")
+        .classList.toggle("hidden", Boolean(value));
+    });
+  },
+  handleBuild({ label = "", type = "content" }) {
+    const __inputID__ = makeLabelID(label);
+
+    let inputElement;
+
+    switch (type) {
+      case "text":
+      case "password":
+      case "email":
+      case "search":
+        inputElement = Frontend.Element
+          .html`<input id="${__inputID__}" type="${type}">`;
+        break;
+      case "content":
+      default:
+        inputElement = Frontend.Element.html`
             <style>
               b, i, u { color: var(--color-foreground); }
               b { font-weight: bold; }
@@ -106,14 +103,13 @@ Frontend.Element.Register("core-input", {
               u { text-decoration: underline; }
             </style>
             <div id="${__inputID__}" contenteditable="true"></div>`;
-      }
+    }
 
-      return Frontend.Element.html`
+    return Frontend.Element.html`
         ${sharedStyles}
         <div class="wrapper">
           <label for="${__inputID__}">${label}</label>
           ${inputElement}
         </div>`;
-    }
   }
 });

--- a/app/elements/core/input.js
+++ b/app/elements/core/input.js
@@ -1,7 +1,6 @@
 import Frontend from "/framework/frontend/module.js";
 
 const sharedStyles = Frontend.Element.html`<style>
-  :host,
   .wrapper,
   input,
   [contenteditable="true"],
@@ -80,7 +79,7 @@ Frontend.Element.Register("core-input", {
     }
   },
   template: {
-    attributes: {
+    buildAttributes: {
       label: String,
       type: String
     },

--- a/app/elements/core/link.js
+++ b/app/elements/core/link.js
@@ -2,7 +2,7 @@ import Frontend from "/framework/frontend/module.js";
 
 Frontend.Element.Register("core-link", {
   template: {
-    attributes: {
+    buildAttributes: {
       href: String
     },
     handleBuild({ href = "#" }) {

--- a/app/elements/core/link.js
+++ b/app/elements/core/link.js
@@ -1,12 +1,11 @@
 import Frontend from "/framework/frontend/module.js";
 
 Frontend.Element.Register("core-link", {
-  template: {
-    buildAttributes: {
-      href: String
-    },
-    handleBuild({ href = "#" }) {
-      return Frontend.Element.html`<style>
+  buildAttributes: {
+    href: String
+  },
+  handleBuild({ href = "#" }) {
+    return Frontend.Element.html`<style>
           a,
           a::selection {
             cursor: ne-resize;
@@ -22,6 +21,5 @@ Frontend.Element.Register("core-link", {
           }
         </style>
         <a href="${href}" target="_blank"><slot></slot></a>`;
-    }
   }
 });

--- a/app/elements/core/loading/skeleton.js
+++ b/app/elements/core/loading/skeleton.js
@@ -1,9 +1,8 @@
 import Frontend from "/framework/frontend/module.js";
 
 Frontend.Element.Register("core-loading-skeleton", {
-  template: {
-    handleBuild() {
-      return Frontend.Element.html`<style>
+  handleBuild() {
+    return Frontend.Element.html`<style>
         div {
           display: block;
           width: 100%;
@@ -29,6 +28,5 @@ Frontend.Element.Register("core-loading-skeleton", {
         }
       </style>
       <div></div>`;
-    }
   }
 });

--- a/app/elements/core/text.js
+++ b/app/elements/core/text.js
@@ -1,12 +1,11 @@
 import Frontend from "/framework/frontend/module.js";
 
 Frontend.Element.Register("core-text", {
-  template: {
-    buildAttributes: {
-      type: String
-    },
-    handleBuild({ type = "paragraph" }) {
-      return Frontend.Element.html`<style>
+  buildAttributes: {
+    type: String
+  },
+  handleBuild({ type = "paragraph" }) {
+    return Frontend.Element.html`<style>
           slot {
             cursor: inherit;
             font-family: system-ui;
@@ -20,6 +19,5 @@ Frontend.Element.Register("core-text", {
           }
         </style>
         <slot></slot>`;
-    }
   }
 });

--- a/app/elements/core/text.js
+++ b/app/elements/core/text.js
@@ -2,7 +2,7 @@ import Frontend from "/framework/frontend/module.js";
 
 Frontend.Element.Register("core-text", {
   template: {
-    attributes: {
+    buildAttributes: {
       type: String
     },
     handleBuild({ type = "paragraph" }) {

--- a/app/pages/__gallery__.js
+++ b/app/pages/__gallery__.js
@@ -4,15 +4,14 @@ import * as constants from "/app/constants.js";
 import OnlyWebTheme from "/app/pages/shared-theme.js";
 
 Backend.Page.Register("/__gallery__", {
-  responses: {
-    handleDefault: (request, inliner) => {
-      const logoSrc =
-        (request.url.origin.match(/localhost/)
-          ? request.url.origin
-          : constants.KEYCDN_IMAGE_ZONE_URL) +
-        "/app/assets/images/logo/maskable.png";
+  handleRequest: (request, inliner) => {
+    const logoSrc =
+      (request.url.origin.match(/localhost/)
+        ? request.url.origin
+        : constants.KEYCDN_IMAGE_ZONE_URL) +
+      "/app/assets/images/logo/maskable.png";
 
-      return Backend.Page.Response.html`<head>
+    return Backend.Page.Response.html`<head>
         <meta charset="utf-8" />
         <link rel="icon" href="/app/assets/images/logo/maskable.png" />
         <link rel="manifest" href="/app/assets/manifest.json" />
@@ -158,6 +157,5 @@ Backend.Page.Register("/__gallery__", {
           </section>
         </article>
       </body>`;
-    }
   }
 });

--- a/app/pages/__gallery__.js
+++ b/app/pages/__gallery__.js
@@ -4,7 +4,9 @@ import * as constants from "/app/constants.js";
 import OnlyWebTheme from "/app/pages/shared-theme.js";
 
 Backend.Page.Register("/__gallery__", {
-  handleRequest: (request, inliner) => {
+  handleRequest: async (request) => {
+    const inliner = await Backend.Page.Inliner(request, "/app/assets/messages");
+
     const logoSrc =
       (request.url.origin.match(/localhost/)
         ? request.url.origin

--- a/app/pages/default.js
+++ b/app/pages/default.js
@@ -149,7 +149,7 @@ Backend.Page.Register(route, {
           <main>
           <nav>
             <header>
-              <core-image src="${logoSrc}" alt="logo" width="64" height="64"></core-image>
+              <core-image src="${logoSrc}" alt="logo" width="64px" height="64px"></core-image>
               <core-text type="title">${inliner.message(
                 "only web 2"
               )}</core-text>

--- a/app/pages/default.js
+++ b/app/pages/default.js
@@ -6,8 +6,9 @@ import OnlyWebTheme from "/app/pages/shared-theme.js";
 const route = "/";
 
 Backend.Page.Register(route, {
-  messagesFolder: "/app/assets/messages",
-  handleRequest: (request, inliner) => {
+  handleRequest: async (request, inliner) => {
+    const inliner = await Backend.Page.Inliner(request, "/app/assets/messages");
+
     const logoSrc =
       (request.url.origin.match(/localhost/)
         ? request.url.origin

--- a/app/pages/default.js
+++ b/app/pages/default.js
@@ -6,7 +6,7 @@ import OnlyWebTheme from "/app/pages/shared-theme.js";
 const route = "/";
 
 Backend.Page.Register(route, {
-  handleRequest: async (request, inliner) => {
+  handleRequest: async (request) => {
     const inliner = await Backend.Page.Inliner(request, "/app/assets/messages");
 
     const logoSrc =

--- a/app/pages/default.js
+++ b/app/pages/default.js
@@ -6,18 +6,15 @@ import OnlyWebTheme from "/app/pages/shared-theme.js";
 const route = "/";
 
 Backend.Page.Register(route, {
-  inliner: {
-    messages: "/app/assets/messages"
-  },
-  responses: {
-    handleDefault: (request, inliner) => {
-      const logoSrc =
-        (request.url.origin.match(/localhost/)
-          ? request.url.origin
-          : constants.KEYCDN_IMAGE_ZONE_URL) +
-        "/app/assets/images/logo/black.svg";
+  messagesFolder: "/app/assets/messages",
+  handleRequest: (request, inliner) => {
+    const logoSrc =
+      (request.url.origin.match(/localhost/)
+        ? request.url.origin
+        : constants.KEYCDN_IMAGE_ZONE_URL) +
+      "/app/assets/images/logo/black.svg";
 
-      return Backend.Page.Response.html`<head>
+    return Backend.Page.Response.html`<head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="manifest" href="/app/assets/manifest.json" />
@@ -210,8 +207,8 @@ Backend.Page.Register(route, {
             });
           </script>
         </body>`;
-    },
-    handleServiceWorker: () => Backend.Page.Response.js`
+  },
+  handleServiceWorker: () => Backend.Page.Response.js`
       self.addEventListener("install", (event) => {
         event.waitUntil(
           caches.open("${route}").then((cache) => {
@@ -236,5 +233,4 @@ Backend.Page.Register(route, {
           });
         }));
       });`
-  }
 });

--- a/app/pages/favicon.js
+++ b/app/pages/favicon.js
@@ -4,12 +4,10 @@ import { serveFile } from "https://deno.land/std@0.140.0/http/file_server.ts";
 import Backend from "/framework/backend/module.js";
 
 Backend.Page.Register("/favicon.ico", {
-  responses: {
-    handleDefault: (request) => {
-      return serveFile(
-        request,
-        resolve(Deno.cwd(), "./app/assets/images/logo/maskable.png")
-      );
-    }
+  handleRequest: (request) => {
+    return serveFile(
+      request,
+      resolve(Deno.cwd(), "./app/assets/images/logo/maskable.png")
+    );
   }
 });

--- a/app/pages/robots.js
+++ b/app/pages/robots.js
@@ -1,9 +1,7 @@
 import Backend from "/framework/backend/module.js";
 
 Backend.Page.Register("/robots.txt", {
-  responses: {
-    handleDefault: () => Backend.Page.Response.text`
+  handleRequest: () => Backend.Page.Response.text`
     User-agent: *
     Allow: /`
-  }
 });

--- a/framework/README.md
+++ b/framework/README.md
@@ -189,14 +189,14 @@ Frontend.Element.Register("copy-code", {
   buildAttributes: { copied: Boolean, ["copy-message"]: String, code: String },
   handleMount: () => {
     this.addEventListener("click", () => {
-      if (this.template.attributes.copied) {
+      if (this.buildAttributes.copied) {
         return;
       }
 
-      globalThis.navigator.clipboard.writeText(this.templateAttributes.code);
+      globalThis.navigator.clipboard.writeText(this.buildAttributes.code);
 
-      this.template.querySelector("div[popover]").togglePopover();
-      this.template.attributes.copied = true;
+      this.querySelector("div[popover]").togglePopover();
+      this.buildAttributes.copied = true;
     });
   },
   handleBuild: ({ code, copied, ["copy-message"]: copyMessage }) => Frontend.Element.html`

--- a/framework/README.md
+++ b/framework/README.md
@@ -95,7 +95,7 @@ This is abstract, so let's walk through a simple example to make things more con
 import Backend from "https://github.com/daniellacosse-code/onlyweb.dev/raw/master/framework/backend/module.js";
 
 Backend.Page.Register("/", {
-  handleRequest: (request) => Backend.Page.Response.html`
+  handleRequest: async (request) => Backend.Page.Response.html`
     <body>
       <h1>Your search is: ${request.url.search}</h1>
     </body>
@@ -105,21 +105,24 @@ Backend.Page.Register("/", {
 ```
 
 2. The default response has no metadata, so external sites won't know how to display it.
-   Use the **Inliner** to add some:
+   Create an **Inliner** to add some:
 
 ```js
 Backend.Page.Register("/", {
-  handleRequest: (request, inliner) => Backend.Page.Response.html`
-    <head>
-      ${inliner.metadata({
-        title: "what's my search?",
-        description: "a simple page that shows the search query",
-      })}
-    </head>
-    <body>
-      <h1>Your search is: ${request.url.search}</h1>
-    </body>
-  `;
+  handleRequest: async (request) => {
+    const inliner = await Backend.Page.Inliner(request);
+
+    return Backend.Page.Response.html`
+      <head>
+        ${inliner.metadata({
+          title: "what's my search?",
+          description: "a simple page that shows the search query",
+        })}
+      </head>
+      <body>
+        <h1>Your search is: ${request.url.search}</h1>
+      </body>
+    `;
   }
 );
 ```
@@ -128,19 +131,22 @@ Backend.Page.Register("/", {
 
 ```js
 Backend.Page.Register("/", {
-  messagesFolder: "%path/to/messages/folder%",
-  handleRequest: (request, inliner) => Backend.Page.Response.html`
-    <head>
-      ${inliner.metadata({
-        title: inliner.message("what's my search?"),
-        description: inliner.message("a simple page that shows the search query"),
-      })}
-    </head>
-    <body>
-      <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
-    </body>
-  `;
-});
+  handleRequest: async (request) => {
+    const inliner = await Backend.Page.Inliner(request, "%path/to/messages/folder%");
+
+    return Backend.Page.Response.html`
+      <head>
+        ${inliner.metadata({
+          title: inliner.message("what's my search?"),
+          description: inliner.message("a simple page that shows the search query"),
+        })}
+      </head>
+      <body>
+        <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
+      </body>
+    `;
+  }
+);
 ```
 
 4. We want to be able to easily copy our search string to the clipboard. We'll have to create a new frontend **Element** to do this. Here's that initial file:
@@ -220,21 +226,23 @@ Frontend.Element.Register("copy-code", {
 
 ```js
 Backend.Page.Register("/", {
-  messagesFolder: "%path/to/messages/folder%",
-  handleRequest: (request, inliner) => Backend.Page.Response.html`
-    <head>
-      ${inliner.metadata({
-        title: inliner.message("what's my search?"),
-        description: inliner.message("a simple page that shows the search query"),
-      })}
-    </head>
-    <body>
-      <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
+  handleRequest: async (request) => {
+    const inliner = await Backend.Page.Inliner(request, "%path/to/messages/folder%");
 
-      ${inliner.elements("%path/to/element/copy-code.js%")}
-      <copy-code code="${request.url,search}" copy-message="${inliner.message("Copied!")}"></copy-code>
-    </body>
-  `;
+    return Backend.Page.Response.html`
+      <head>
+        ${inliner.metadata({
+          title: inliner.message("what's my search?"),
+          description: inliner.message("a simple page that shows the search query"),
+        })}
+      </head>
+      <body>
+        <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
+
+        ${inliner.elements("%path/to/element/copy-code.js%")}
+        <copy-code code="${request.url.search}" copy-message="${inliner.message("Copied!")}"></copy-code>
+      </body>
+    `;
   }
 );
 ```

--- a/framework/README.md
+++ b/framework/README.md
@@ -131,6 +131,9 @@ Backend.Page.Register("/", {
 
 ```js
 Backend.Page.Register("/", {
+  inliner: {
+    messages: "%path/to/messages/folder%"
+  },
   responses: {
     handleDefault: (request, inliner) => Backend.Page.Response.html`
       <head>
@@ -143,9 +146,6 @@ Backend.Page.Register("/", {
         <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
       </body>
     `;
-  },
-  inliner: {
-    messages: "%path/to/messages/folder%"
   }
 });
 ```
@@ -227,6 +227,9 @@ Frontend.Element.Register("copy-code", {
 
 ```js
 Backend.Page.Register("/", {
+  inliner: {
+    messages: "%path/to/messages/folder%"
+  },
   responses: {
     handleDefault: (request, inliner) => Backend.Page.Response.html`
       <head>
@@ -242,9 +245,6 @@ Backend.Page.Register("/", {
         <copy-code code="${request.url,search}" copy-message="${inliner.message("Copied!")}"></copy-code>
       </body>
     `;
-  },
-  inliner: {
-    messages: "%path/to/messages/folder%"
   }
 });
 ```

--- a/framework/README.md
+++ b/framework/README.md
@@ -95,15 +95,13 @@ This is abstract, so let's walk through a simple example to make things more con
 import Backend from "https://github.com/daniellacosse-code/onlyweb.dev/raw/master/framework/backend/module.js";
 
 Backend.Page.Register("/", {
-  responses: {
-    handleDefault: (request) => Backend.Page.Response.html`
-        <body>
-          <h1>Your search is: ${request.url.search}</h1>
-        </body>
-      `;
-    }
+  handleRequest: (request) => Backend.Page.Response.html`
+    <body>
+      <h1>Your search is: ${request.url.search}</h1>
+    </body>
+  `;
   }
-});
+);
 ```
 
 2. The default response has no metadata, so external sites won't know how to display it.
@@ -111,42 +109,37 @@ Backend.Page.Register("/", {
 
 ```js
 Backend.Page.Register("/", {
-  responses: {
-    handleDefault: (request, inliner) => Backend.Page.Response.html`
-      <head>
-        ${inliner.metadata({
-          title: "what's my search?",
-          description: "a simple page that shows the search query",
-        })}
-      </head>
-      <body>
-        <h1>Your search is: ${request.url.search}</h1>
-      </body>
-    `;
+  handleRequest: (request, inliner) => Backend.Page.Response.html`
+    <head>
+      ${inliner.metadata({
+        title: "what's my search?",
+        description: "a simple page that shows the search query",
+      })}
+    </head>
+    <body>
+      <h1>Your search is: ${request.url.search}</h1>
+    </body>
+  `;
   }
-});
+);
 ```
 
 3. Our page only works in English. Provide the **Inliner** with [a folder of translations like this one](../app/assets/messages/) so we can support those languages:
 
 ```js
 Backend.Page.Register("/", {
-  inliner: {
-    messages: "%path/to/messages/folder%"
-  },
-  responses: {
-    handleDefault: (request, inliner) => Backend.Page.Response.html`
-      <head>
-        ${inliner.metadata({
-          title: inliner.message("what's my search?"),
-          description: inliner.message("a simple page that shows the search query"),
-        })}
-      </head>
-      <body>
-        <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
-      </body>
-    `;
-  }
+  messagesFolder: "%path/to/messages/folder%",
+  handleRequest: (request, inliner) => Backend.Page.Response.html`
+    <head>
+      ${inliner.metadata({
+        title: inliner.message("what's my search?"),
+        description: inliner.message("a simple page that shows the search query"),
+      })}
+    </head>
+    <body>
+      <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
+    </body>
+  `;
 });
 ```
 
@@ -227,26 +220,23 @@ Frontend.Element.Register("copy-code", {
 
 ```js
 Backend.Page.Register("/", {
-  inliner: {
-    messages: "%path/to/messages/folder%"
-  },
-  responses: {
-    handleDefault: (request, inliner) => Backend.Page.Response.html`
-      <head>
-        ${inliner.metadata({
-          title: inliner.message("what's my search?"),
-          description: inliner.message("a simple page that shows the search query"),
-        })}
-      </head>
-      <body>
-        <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
+  messagesFolder: "%path/to/messages/folder%",
+  handleRequest: (request, inliner) => Backend.Page.Response.html`
+    <head>
+      ${inliner.metadata({
+        title: inliner.message("what's my search?"),
+        description: inliner.message("a simple page that shows the search query"),
+      })}
+    </head>
+    <body>
+      <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
 
-        ${inliner.elements("%path/to/element/copy-code.js%")}
-        <copy-code code="${request.url,search}" copy-message="${inliner.message("Copied!")}"></copy-code>
-      </body>
-    `;
+      ${inliner.elements("%path/to/element/copy-code.js%")}
+      <copy-code code="${request.url,search}" copy-message="${inliner.message("Copied!")}"></copy-code>
+    </body>
+  `;
   }
-});
+);
 ```
 
 7. HTML popovers aren't super supported yet, so let's indicate that in our pages' requirements:

--- a/framework/README.md
+++ b/framework/README.md
@@ -59,8 +59,8 @@ block-beta
     columns 2
     frontend:2
     element:2
-    host
-    template
+    attributes
+    build
   end
 ```
 
@@ -76,11 +76,11 @@ The backend server serves content via Deno. Key concepts:
 
 ### frontend
 
-The frontend renders content in the browser via WebComponnents. Key concepts:
+The frontend renders content in the browser via WebComponents. Key concepts:
 
 1. **Element**: an HTML tag representing some meaningful section or component of your application. Each custom **Element** is basically like a little, nested website. [Learn more about HTML Elements here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element).
-2. **Host**: an in-memory object representing the current **Element** instance. Through its **Host** you access an **Element**'s lifecycle, events, and parent context. Think of it as the _"face"_ of the **Element**.
-3. **Template**: the blueprint for the **Element**'s internals, driven by a set of data attributes you select. It's a bit of a departure from the norm, but think of it as the _"guts"_ of the **Element**.
+2. **Attribute**: a property of an **Element** that can be set and read. Attributes are used to pass data to **Elements**. [Learn more about HTML Attributes here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).
+3. **Build**: the process of creating an **Element** from a set of **Attributes**. This is where you define the structure of your **Element**.
 
 This is abstract, so let's walk through a simple example to make things more concrete.
 
@@ -156,82 +156,70 @@ Backend.Page.Register("/", {
 import Frontend from "https://github.com/daniellacosse-code/onlyweb.dev/raw/master/framework/frontend/module.js";
 
 Frontend.Element.Register("copy-code", {
-  template: {
-    attributes: { copied: Boolean, ["copy-message"]: String, code: String },
-    // Note that the html template tag here is different than the Backends'
-    handleBuild: ({ code, copied, ["copy-message"]: copyMessage }) => Frontend.Element.html`
-      <style>
-        div {
-          display: relative;
-        }
-        code {
-          font-family: monospace;
-          font-size: 1rem;
-          text-overflow: ellipsis;
-        }
-        div[popover] {
-          display: absolute;
-          top: 0;
-          left: 0;
-        }
-      </style>
-      <div>
-        <code>${code}</code>
-        <div popover>${copyMessage}</div>
-      </div>
-    `;
-  }
+  buildAttributes: { copied: Boolean, ["copy-message"]: String, code: String },
+  // Note that the html template tag here is different than the Backends'
+  handleBuild: ({ code, copied, ["copy-message"]: copyMessage }) => Frontend.Element.html`
+    <style>
+      div {
+        display: relative;
+      }
+      code {
+        font-family: monospace;
+        font-size: 1rem;
+        text-overflow: ellipsis;
+      }
+      div[popover] {
+        display: absolute;
+        top: 0;
+        left: 0;
+      }
+    </style>
+    <div>
+      <code>${code}</code>
+      <div popover>${copyMessage}</div>
+    </div>
+  `;
 });
 ```
 
-> [!TIP]
-> Think of each onlyweb element as a little website that's hosted by the parent website. This means that if you style the `:host` in the template, those styles are modifiable by the host. Be aware of what that host might be! Each onlyweb element resets its styles for cross-browser consistency, so that will happen when you host an element inside another element. If you have styles you want to be consistent across all instances of an element, often it makes sense to style the `<slot>` or a wrapper.
-
-> **TODO([#193](https://github.com/daniellacosse-code/onlyweb.dev/issues/193)): short guide on when to use `:host` selector in the template**
-
-5. The onlyweb framework simply wraps the existing Event API to handle I/O. To do the copy, listen for a click event on the **Host**:
+5. The onlyweb framework simply wraps the existing Event API to handle I/O. To do the copy, listen for a click event on mount:
 
 ```js
 Frontend.Element.Register("copy-code", {
-  host: {
-    handleMount: () => {
-      this.addEventListener("click", () => {
-        if (this.template.attributes.copied) {
-          return;
-        }
+  buildAttributes: { copied: Boolean, ["copy-message"]: String, code: String },
+  handleMount: () => {
+    this.addEventListener("click", () => {
+      if (this.template.attributes.copied) {
+        return;
+      }
 
-        globalThis.navigator.clipboard.writeText(this.templateAttributes.code);
+      globalThis.navigator.clipboard.writeText(this.templateAttributes.code);
 
-        this.template.querySelector("div[popover]").togglePopover();
-        this.template.attributes.copied = true;
-      });
-    }
+      this.template.querySelector("div[popover]").togglePopover();
+      this.template.attributes.copied = true;
+    });
   },
-  template: {
-    attributes: { copied: Boolean, ["copy-message"]: String, code: String },
-    // Note that the html template tag here is different than the Backends'
-    handleBuild: ({ code, copied, ["copy-message"]: copyMessage }) => Frontend.Element.html`
-      <style>
-        div {
-          display: relative;
-        }
-        code {
-          font-family: monospace;
-          font-size: 1rem;
-          text-overflow: ellipsis;
-        }
-        div[popover] {
-          display: absolute;
-          top: 0;
-          left: 0;
-        }
-      </style>
-      <div>
-        <code>${code}</code>
-        <div popover>${copyMessage}</div>
-      </div>
-    `;
-  }
+  handleBuild: ({ code, copied, ["copy-message"]: copyMessage }) => Frontend.Element.html`
+    <style>
+      div {
+        display: relative;
+      }
+      code {
+        font-family: monospace;
+        font-size: 1rem;
+        text-overflow: ellipsis;
+      }
+      div[popover] {
+        display: absolute;
+        top: 0;
+        left: 0;
+      }
+    </style>
+    <div>
+      <code>${code}</code>
+      <div popover>${copyMessage}</div>
+    </div>
+  `;
 });
 ```
 

--- a/framework/backend/page/model.js
+++ b/framework/backend/page/model.js
@@ -28,7 +28,7 @@
 
 /**
  * A handler for a page request.
- * @typedef {(request: PageRequest, inliner: Inliner) => Promise<PageResponse>} PageHandler
+ * @typedef {(request: PageRequest) => Promise<PageResponse>} PageHandler
  * @memberof Page
  */
 

--- a/framework/backend/page/register.js
+++ b/framework/backend/page/register.js
@@ -2,7 +2,6 @@
 
 import PageResponse from "./response.js";
 import * as constants from "../constants.js";
-import Inliner from "./inliner.js";
 import Shared from "/framework/shared/module.js";
 
 /**
@@ -52,7 +51,6 @@ export default (
   route,
   {
     requirements = { renderer: {}, engine: {} },
-    messagesFolder,
     handleRequest,
     handleServiceWorker = () => PageResponse.html``
   }
@@ -81,8 +79,6 @@ export default (
         request.headers.get("accept-language")?.split(",")[0] ??
         "en-US";
 
-      const inliner = await Inliner(request, messagesFolder ?? "");
-
       Shared.Log({
         message: `[framework/backend/register] Begun handling request @ "${route}".`,
         detail: request
@@ -93,7 +89,7 @@ export default (
           Shared.Log({
             message: `[framework/backend/register] Constructing service worker response @ "${route}".`
           });
-          const serviceWorker = await handleServiceWorker(request, inliner);
+          const serviceWorker = await handleServiceWorker(request);
 
           if (!serviceWorker) {
             Shared.Log({
@@ -121,7 +117,7 @@ export default (
       });
 
       /** @type {PageResponse} */
-      const response = await handleRequest(request, inliner);
+      const response = await handleRequest(request);
 
       if (response.mimetype !== "text/html") {
         Shared.Log({

--- a/framework/backend/page/register.js
+++ b/framework/backend/page/register.js
@@ -17,12 +17,10 @@ import Shared from "/framework/shared/module.js";
  * Registers a custom page in the global customPages map.
  * @param {string} route The route of the page
  * @param {object} pageOptions The options for the page
- * @param {object} [pageOptions.inliner] The page inliner configuration
- * @param {PlatformRequirements} [pageOptions.inliner.requirements] The platform requirements for the inliner
- * @param {string} [pageOptions.inliner.messages] The messages for the inliner
- * @param {object} pageOptions.responses The response handlers for the page
- * @param {PageHandler} pageOptions.responses.handleDefault The request handler for the page
- * @param {PageHandler} [pageOptions.responses.handleServiceWorker] The service worker request handler for the page
+ * @param {PlatformRequirements} [pageOptions.requirements] The platform requirements for the inliner
+ * @param {string} [pageOptions.messagesFolder] The messages for the inliner
+ * @param {PageHandler} pageOptions.handleRequest The request handler for the page
+ * @param {PageHandler} [pageOptions.handleServiceWorker] The service worker request handler for the page
  * @example Backend.Page.Register("/test", {
  *  requirements: {
  *    engine: { Chrome: 91 },
@@ -39,7 +37,7 @@ import Shared from "/framework/shared/module.js";
  *          <h1>Hello, world!</h1>
  *        </body>
  *     </html>`,
- * handleServiceWorkerRequest: (request) => Backend.Page.Response.js`
+ * handleServiceWorker: (request) => Backend.Page.Response.js`
  *  self.addEventListener("install", (event) => {
  *    event.waitUntil(
  *      caches.open("test").then((cache) => {
@@ -53,11 +51,10 @@ import Shared from "/framework/shared/module.js";
 export default (
   route,
   {
-    inliner: { requirements = { renderer: {}, engine: {} }, messages } = {},
-    responses: {
-      handleDefault,
-      handleServiceWorker = () => PageResponse.html``
-    }
+    requirements = { renderer: {}, engine: {} },
+    messagesFolder,
+    handleRequest,
+    handleServiceWorker = () => PageResponse.html``
   }
 ) => {
   /** @type {typeof globalThis & { customPages?: Map<string, PageHandler> }} */
@@ -84,24 +81,21 @@ export default (
         request.headers.get("accept-language")?.split(",")[0] ??
         "en-US";
 
-      const inliner = await Inliner(request, messages ?? "");
+      const inliner = await Inliner(request, messagesFolder ?? "");
 
       Shared.Log({
         message: `[framework/backend/register] Begun handling request @ "${route}".`,
         detail: request
       });
 
-      if (request.url.searchParams.has("service")) {
+      if (request.url.searchParams.has("sw")) {
         try {
           Shared.Log({
             message: `[framework/backend/register] Constructing service worker response @ "${route}".`
           });
-          const serviceWorkerResponse = await handleServiceWorker(
-            request,
-            inliner
-          );
+          const serviceWorker = await handleServiceWorker(request, inliner);
 
-          if (!serviceWorkerResponse) {
+          if (!serviceWorker) {
             Shared.Log({
               message: `[framework/backend/register] No service worker found @ "${route}".`,
               level: "warn"
@@ -111,10 +105,10 @@ export default (
 
           Shared.Log({
             message: `[framework/backend/register] Serving service worker @ "${route}".`,
-            detail: serviceWorkerResponse
+            detail: serviceWorker
           });
 
-          return serviceWorkerResponse;
+          return serviceWorker;
         } catch (error) {
           Shared.LogError(error);
           return new Response("Internal Server Error", { status: 500 });
@@ -127,7 +121,7 @@ export default (
       });
 
       /** @type {PageResponse} */
-      const response = await handleDefault(request, inliner);
+      const response = await handleRequest(request, inliner);
 
       if (response.mimetype !== "text/html") {
         Shared.Log({
@@ -183,7 +177,7 @@ export default (
                 // register service worker
                 if ("serviceWorker" in navigator) {
                   try {
-                    navigator.serviceWorker.register("${route}?service", {
+                    navigator.serviceWorker.register("${route}?sw", {
                       scope: "${route}"
                     });
                   } catch (error) {

--- a/framework/backend/page/register.test.js
+++ b/framework/backend/page/register.test.js
@@ -3,10 +3,8 @@ import register from "/framework/backend/page/register.js";
 
 Deno.test("register", async () => {
   await register("/", {
-    responses: {
-      handleDefault: () => new Response(),
-      handleServiceWorker: () => new Response()
-    }
+    handleRequest: () => new Response(),
+    handleServiceWorker: () => new Response()
   });
 
   assertEquals(Boolean(globalThis.customPages.get("/")), true);

--- a/framework/frontend/element/register.js
+++ b/framework/frontend/element/register.js
@@ -164,6 +164,18 @@ export default (
         );
       }
 
+      /**
+       * @param {string} selector
+       * @returns {HTMLElement | null}
+       * @throws {Error} Throws an error if the selector is invalid
+       * @example
+       * const myElement = document.querySelector("my-element");
+       * myElement.querySelector("div");
+       */
+      querySelector(selector) {
+        return this.template.querySelector(selector);
+      }
+
       #buildTemplate() {
         if (!this.template) {
           Shared.Log({

--- a/framework/frontend/element/register.js
+++ b/framework/frontend/element/register.js
@@ -9,13 +9,10 @@ import html from "./html.js";
  * Registers a custom element with the global customElements map
  * @param {string} tag The tag of the element
  * @param {object} options The options setting up the element
- * @param {object} [options.host] The host options
- * @param {HTMLCollection} [options.host.defaultStyles] The default styles of the host element
- * @param {(attributes: object) => void} [options.host.handleMount] Is called when the element is mounted: use it to set up the shadow DOM and register event listeners
- * @param {(attributes: object) => void} [options.host.handleDismount] The dismount handler: use it to clean up event listeners and other resources
- * @param {object} options.template The template options
- * @param {{ [name: string]: function }} [options.template.buildAttributes] The attributes of the element, that, when modified, will trigger a template build
- * @param {(attributes: object) => HTMLCollection} options.template.handleBuild The core of the element: use it to build the template from which the shadow DOM will be constructed
+ * @param {{ [name: string]: function }} [options.buildAttributes] The attributes of the element, that, when modified, will trigger a template build
+ * @param {(attributes: object) => HTMLCollection} options.handleBuild The core of the element: use it to build the template from which the shadow DOM will be constructed
+ * @param {(attributes: object) => void} [options.handleMount] Is called when the element is mounted: use it to set up the shadow DOM and register event listeners
+ * @param {(attributes: object) => void} [options.handleDismount] The dismount handler: use it to clean up event listeners and other resources
  * @example Register("my-element", {
  *  template: {
  *    attributes: {
@@ -30,14 +27,10 @@ import html from "./html.js";
 export default (
   tag,
   {
-    host: {
-      defaultStyles = html`<style></style>`,
-      handleMount = () => {},
-      handleDismount = () => {}
-    } = {},
-    template: { buildAttributes = {}, handleBuild } = {
-      handleBuild: () => html`<slot></slot>`
-    }
+    buildAttributes = {},
+    handleBuild,
+    handleMount = () => {},
+    handleDismount = () => {}
   }
 ) => {
   if (globalThis.customElements.get(tag))
@@ -203,7 +196,7 @@ export default (
               display: none;
             }
           </style>
-          ${defaultStyles} ${templateResult}
+          ${templateResult}
         </template>`;
 
         this.template.replaceChildren(...templateWrapper);

--- a/framework/frontend/element/register.test.js
+++ b/framework/frontend/element/register.test.js
@@ -26,7 +26,7 @@ globalThis.document = {
 };
 
 Deno.test("element - register", async () => {
-  await register("my-element", {});
+  await register("my-element", { handleBuild: () => {} });
 
   assertEquals(Boolean(globalThis.customElements.get("my-element")), true);
   assertEquals(
@@ -36,7 +36,7 @@ Deno.test("element - register", async () => {
 });
 
 Deno.test("element - addEventListener", async () => {
-  await register("my-element", {});
+  await register("my-element", { handleBuild: () => {} });
 
   const element = new globalThis.customElements["my-element"]();
 

--- a/framework/frontend/element/register.test.js
+++ b/framework/frontend/element/register.test.js
@@ -19,6 +19,12 @@ globalThis.HTMLElement = class HTMLElement {
   addEventListener() {}
 };
 
+globalThis.document = {
+  createElement() {
+    return new globalThis.HTMLElement();
+  }
+};
+
 Deno.test("element - register", async () => {
   await register("my-element", {});
 


### PR DESCRIPTION
TODOs:
- [x] fix `core-image`
- [x] can we `*:not(:host)` the reset?
- [x] I think mount/dismount should take all attributes, not just the template ones
- [x] update tutorial
- [x] I think we may want to create the inliner, like this:

```js
Backend.Page.Register("/", {
  handleRequest: (request) => {
     const inliner = Backend.Page.Inliner(request, "%path/to/messages/folder%");

     return Backend.Page.Response.html`
      <head>
        ${inliner.metadata({
          title: inliner.message("what's my search?"),
          description: inliner.message("a simple page that shows the search query"),
        })}
      </head>
      <body>
        <h1>${inliner.message("Your search is:")} ${request.url.search}</h1>
      </body>
    `;
  }
);
```